### PR TITLE
fix: Still extra "/" in canonical urls

### DIFF
--- a/lib/generator/methods.js
+++ b/lib/generator/methods.js
@@ -104,7 +104,7 @@ function generateCanonicalURL (fileData, config) {
   const datePart = fileData.name.split('-')
   datePart.length = 3
   const titlePart = fileData.name.split('-').slice(3).join('-')
-  return config.site.url.replace(/\/$/, ''); + '/' + (datePart.join('/') + '/' + titlePart + '.html')
+  return config.site.url.replace(/\/$/, '') + '/' + (datePart.join('/') + '/' + titlePart + '.html')
 }
 /**
  * Generate postid for the post (needed for disqus)

--- a/site-generator/generator/methods.js
+++ b/site-generator/generator/methods.js
@@ -119,7 +119,7 @@ function generateCanonicalURL (fileData: any, config: any): string {
 
   const titlePart: string = fileData.name.split('-').slice(3).join('-')
 
-  return config.site.url.replace(/\/$/, ''); + '/' + (datePart.join('/') + '/' + titlePart + '.html')
+  return config.site.url.replace(/\/$/, '') + '/' + (datePart.join('/') + '/' + titlePart + '.html')
 }
 
 


### PR DESCRIPTION
Maybe the pretty urls post processing adds the extra "/".
It is working on localhost, but not on Netlify.